### PR TITLE
composer-changelogs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^9.6",
+        "pyrech/composer-changelogs": "^2.1",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/browser-kit": "^6.3|^7.0",
         "symfony/css-selector": "^6.3|^7.0",
@@ -41,7 +42,8 @@
             "symfony/flex": true,
             "symfony/runtime": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "pyrech/composer-changelogs": true
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d6ec1bb3a04b75365ee4a121abbb389",
+    "content-hash": "f650148e97244af1d435366530bb48ff",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -6245,6 +6245,63 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
             "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "pyrech/composer-changelogs",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pyrech/composer-changelogs.git",
+                "reference": "f5ee2ad86dcfcc90b3aa1e3b37e5e2064b348204"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pyrech/composer-changelogs/zipball/f5ee2ad86dcfcc90b3aa1e3b37e5e2064b348204",
+                "reference": "f5ee2ad86dcfcc90b3aa1e3b37e5e2064b348204",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^1.9",
+                "symfony/phpunit-bridge": "^6.2"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pyrech\\ComposerChangelogs\\ChangelogsPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pyrech\\ComposerChangelogs\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïck Piera",
+                    "email": "pyrech@gmail.com"
+                }
+            ],
+            "description": "Display changelogs after each composer update",
+            "keywords": [
+                "changelog",
+                "composer",
+                "plugin",
+                "update"
+            ],
+            "support": {
+                "issues": "https://github.com/pyrech/composer-changelogs/issues",
+                "source": "https://github.com/pyrech/composer-changelogs/tree/v2.1.0"
+            },
+            "time": "2023-04-21T10:34:02+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Changelogs summary:

 - pyrech/composer-changelogs installed in version v2.1.0
   Release notes: https://github.com/pyrech/composer-changelogs/releases/tag/v2.1.0

No security vulnerability advisories found.
Using version ^2.1 for pyrech/composer-changelogs
