### PR TITLE
Upgrade PHP-CS-Fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now you can visit https://app.local (or personal domain if you change `SERVER_NA
 ### QA tools: 
 
 - PHP_CodeSniffer [3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2)
-- PHP-CS-Fixer [3.37.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.37.0)
+- PHP-CS-Fixer [3.37.1](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.37.1)
 - PHPStan [1.10.39](https://github.com/phpstan/phpstan/releases/tag/1.10.39)
 - PHP Insights [2.9.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.9.0)
 - Twigcs [6.2.0](https://github.com/friendsoftwig/twigcs/releases/tag/6.2.0)

--- a/composer.lock
+++ b/composer.lock
@@ -4721,16 +4721,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.37.0",
+            "version": "v3.37.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "d5ccc3807fd496ac2b448e8e5e57aa0772f0d18b"
+                "reference": "c3fe76976081ab871aa654e872da588077e19679"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d5ccc3807fd496ac2b448e8e5e57aa0772f0d18b",
-                "reference": "d5ccc3807fd496ac2b448e8e5e57aa0772f0d18b",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/c3fe76976081ab871aa654e872da588077e19679",
+                "reference": "c3fe76976081ab871aa654e872da588077e19679",
                 "shasum": ""
             },
             "require": {
@@ -4802,7 +4802,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.37.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.37.1"
             },
             "funding": [
                 {
@@ -4810,7 +4810,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-28T14:49:50+00:00"
+            "time": "2023-10-29T20:51:23+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",


### PR DESCRIPTION
Changelogs summary:

 - friendsofphp/php-cs-fixer updated from v3.37.0 to v3.37.1 patch
   See changes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.37.0...v3.37.1
   Release notes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.37.1

No security vulnerability advisories found.
