### PR TITLE
Phpstan 1.10.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Now you can visit https://app.local (or personal domain if you change `SERVER_NA
 
 - PHP_CodeSniffer [3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2)
 - PHP-CS-Fixer [3.37.1](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.37.1)
-- PHPStan [1.10.40](https://github.com/phpstan/phpstan/releases/tag/1.10.40)
+- PHPStan [1.10.41](https://github.com/phpstan/phpstan/releases/tag/1.10.41)
 - PHP Insights [2.9.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.9.0)
 - Twigcs [6.2.0](https://github.com/friendsoftwig/twigcs/releases/tag/6.2.0)
 - YML Linter

--- a/composer.lock
+++ b/composer.lock
@@ -5713,16 +5713,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.40",
+            "version": "1.10.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d"
+                "reference": "c6174523c2a69231df55bdc65b61655e72876d76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93c84b5bf7669920d823631e39904d69b9c7dc5d",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6174523c2a69231df55bdc65b61655e72876d76",
+                "reference": "c6174523c2a69231df55bdc65b61655e72876d76",
                 "shasum": ""
             },
             "require": {
@@ -5771,7 +5771,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-30T14:48:31+00:00"
+            "time": "2023-11-05T12:57:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
```
Changelogs summary:

 - phpstan/phpstan updated from 1.10.40 to 1.10.41 patch
   See changes: https://github.com/phpstan/phpstan/compare/1.10.40...1.10.41
   Release notes: https://github.com/phpstan/phpstan/releases/tag/1.10.41

No security vulnerability advisories found.

```