### PR TITLE
Uprade phpinsights to v2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 - PHP_CodeSniffer [3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2)
 - PHP-CS-Fixer [3.38.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.38.0)
 - PHPStan [1.10.41](https://github.com/phpstan/phpstan/releases/tag/1.10.41)
-- PHP Insights [2.9.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.9.0)
+- PHP Insights [2.10.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.10.0)
 - Twigcs [6.2.0](https://github.com/friendsoftwig/twigcs/releases/tag/6.2.0)
 - YML Linter
 - Twig Linter 

--- a/composer.lock
+++ b/composer.lock
@@ -5348,16 +5348,16 @@
         },
         {
             "name": "nunomaduro/phpinsights",
-            "version": "v2.9.0",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/phpinsights.git",
-                "reference": "52d69d895239b1e9a90d7212dffc6c7e73ec822e"
+                "reference": "e0988110b32f79a33cfcab5968a4bd426924b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/phpinsights/zipball/52d69d895239b1e9a90d7212dffc6c7e73ec822e",
-                "reference": "52d69d895239b1e9a90d7212dffc6c7e73ec822e",
+                "url": "https://api.github.com/repos/nunomaduro/phpinsights/zipball/e0988110b32f79a33cfcab5968a4bd426924b191",
+                "reference": "e0988110b32f79a33cfcab5968a4bd426924b191",
                 "shasum": ""
             },
             "require": {
@@ -5434,7 +5434,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/phpinsights/issues",
-                "source": "https://github.com/nunomaduro/phpinsights/tree/v2.9.0"
+                "source": "https://github.com/nunomaduro/phpinsights/tree/v2.10.0"
             },
             "funding": [
                 {
@@ -5450,7 +5450,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-20T15:58:50+00:00"
+            "time": "2023-11-10T03:23:41+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
```
Changelogs summary:

 - nunomaduro/phpinsights updated from v2.9.0 to v2.10.0 minor
   See changes: https://github.com/nunomaduro/phpinsights/compare/v2.9.0...v2.10.0
   Release notes: https://github.com/nunomaduro/phpinsights/releases/tag/v2.10.0

No security vulnerability advisories found.

```