### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 ### QA tools: 
 
 - PHP_CodeSniffer [3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2)
-- PHP-CS-Fixer [3.39.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.39.0)
+- PHP-CS-Fixer [3.39.1](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.39.1)
 - PHPStan [1.10.44](https://github.com/phpstan/phpstan/releases/tag/1.10.44)
 - PHP Insights [2.10.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.10.0)
 - Twigcs [6.2.0](https://github.com/friendsoftwig/twigcs/releases/tag/6.2.0)

--- a/composer.lock
+++ b/composer.lock
@@ -4730,16 +4730,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.39.0",
+            "version": "v3.39.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "04bf7b28fc847185b247d112cab617da941e3cca"
+                "reference": "857046d26b0d92dc13c4be769309026b100b517e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/04bf7b28fc847185b247d112cab617da941e3cca",
-                "reference": "04bf7b28fc847185b247d112cab617da941e3cca",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/857046d26b0d92dc13c4be769309026b100b517e",
+                "reference": "857046d26b0d92dc13c4be769309026b100b517e",
                 "shasum": ""
             },
             "require": {
@@ -4811,7 +4811,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.39.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.39.1"
             },
             "funding": [
                 {
@@ -4819,7 +4819,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-22T11:20:09+00:00"
+            "time": "2023-11-24T22:59:03+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",


### PR DESCRIPTION
```
Changelogs summary:

 - friendsofphp/php-cs-fixer updated from v3.39.0 to v3.39.1 patch
   See changes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.39.0...v3.39.1
   Release notes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.39.1

No security vulnerability advisories found.

```