### PR TITLE
Update php-cs-fixer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4734,12 +4734,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "45a453070b124fa3eed296b6d451a079420f21c9"
+                "reference": "27d2b3265b5d550ec411b4319967ae7cfddfb2e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/45a453070b124fa3eed296b6d451a079420f21c9",
-                "reference": "45a453070b124fa3eed296b6d451a079420f21c9",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/27d2b3265b5d550ec411b4319967ae7cfddfb2e0",
+                "reference": "27d2b3265b5d550ec411b4319967ae7cfddfb2e0",
                 "shasum": ""
             },
             "require": {
@@ -4819,7 +4819,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-26T07:28:10+00:00"
+            "time": "2023-11-26T09:25:53+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",


### PR DESCRIPTION
```
Changelogs summary:

 - friendsofphp/php-cs-fixer updated from v3.40.0 to v3.40.0 patch
   See changes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.40.0...v3.40.0
   Release notes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.40.0

No security vulnerability advisories found.

```