### PR TITLE
Upgrade to PHP 8.3 and removing friendsoftwig/twigcs (EOL)

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ APP_SECRET=234a87276b212258bef5bffd6c24fba9
 
 SERVER_NAME=app.local
 PHP_IMAGE=php
-PHP_VERSION=8.2
+PHP_VERSION=8.3
 
 ###> doctrine/doctrine-bundle ###
 POSTGRES_USER=app

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ restore-db: ## Restore database: make restore-db file=dump.sql
 ## —— ✨ Code Quality ——
 .PHONY: qa
 qa: ## Run all code quality checks
-qa: lint-yaml lint-twig twigcs lint-container phpcs php-cs-fixer phpstan phpinsights
+qa: lint-yaml lint-twig lint-container phpcs php-cs-fixer phpstan phpinsights
 
 .PHONY: qa-fix
 qa-fix: ## Run all code quality fixers
@@ -142,18 +142,12 @@ php-cs-fixer: ## Execute php-cs-fixer in dry-run mode
 php-cs-fixer-apply: ## Execute php-cs-fixer and apply changes
 	$(APP) vendor/bin/php-cs-fixer fix --using-cache=no --verbose
 
-.PHONY: twigcs
-twigcs: ## Twigcs (https://github.com/friendsoftwig/twigcs)
-	$(APP) vendor/bin/twigcs templates --severity error --display blocking
-
-
 ##
 ## —— ✨ Tests ——
 .PHONY: tests
 tests: ## Execute tests
 	$(APP) vendor/bin/simple-phpunit  --colors=always --testdox
 	$(APP) vendor/bin/behat
-
 
 ##
 ## —— ✨ Others ——

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An up to date clean Symfony based on docker (PHP, Caddy, Postgres) with QA and tests tools 
 
 - [Symfony 6.3.8](https://github.com/symfony/symfony/releases/tag/v6.3.8)
-- [PHP 8.2](https://hub.docker.com/r/dmnlouis/php)
+- [PHP 8.3](https://hub.docker.com/r/dmnlouis/php)
 - [Caddy 2.7](https://hub.docker.com/r/dmnlouis/caddy)
 - [Postgres 16](https://hub.docker.com/_/postgres)
 
@@ -21,7 +21,7 @@ Now you can visit https://app.local (or personal domain if you change `SERVER_NA
 You can change `PHP_VERSION` in `.env.local` to switch to another version.  
 Versions available on https://hub.docker.com/r/dmnlouis/php:
 - 8.2
-- 8.3 (RC)
+- 8.3
 
 ### X-Debug:
 #### To use PHP with X-Debug enabled:
@@ -42,7 +42,6 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 - PHP-CS-Fixer [3.40.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.40.0)
 - PHPStan [1.10.44](https://github.com/phpstan/phpstan/releases/tag/1.10.44)
 - PHP Insights [2.10.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.10.0)
-- Twigcs [6.2.0](https://github.com/friendsoftwig/twigcs/releases/tag/6.2.0)
 - YML Linter
 - Twig Linter 
 - Service Container Linter

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "friends-of-behat/mink-extension": "^2.7",
         "friends-of-behat/symfony-extension": "^2.4",
         "friendsofphp/php-cs-fixer": "^3.37",
-        "friendsoftwig/twigcs": "^6.2",
         "nunomaduro/phpinsights": "^2.8",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f650148e97244af1d435366530bb48ff",
+    "content-hash": "c1a7ecd09a0bbd2ca042b4cb8971ce02",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4902,61 +4902,6 @@
                 }
             ],
             "time": "2023-05-24T07:17:17+00:00"
-        },
-        {
-            "name": "friendsoftwig/twigcs",
-            "version": "6.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/friendsoftwig/twigcs.git",
-                "reference": "da697cc1bf6bf22feb1d8dbefcbdb1451e6a35f6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/friendsoftwig/twigcs/zipball/da697cc1bf6bf22feb1d8dbefcbdb1451e6a35f6",
-                "reference": "da697cc1bf6bf22feb1d8dbefcbdb1451e6a35f6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-hash": "*",
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "ext-simplexml": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "symfony/console": "^4.4 || ^5.3 || ^6.0",
-                "symfony/filesystem": "^4.4 || ^5.3 || ^6.0",
-                "symfony/finder": "^4.4 || ^5.3 || ^6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5.27",
-                "symfony/phpunit-bridge": "^6.2.3"
-            },
-            "bin": [
-                "bin/twigcs"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "FriendsOfTwig\\Twigcs\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tristan Maindron",
-                    "email": "tmaindron@gmail.com"
-                }
-            ],
-            "description": "Checkstyle automation for Twig",
-            "support": {
-                "issues": "https://github.com/friendsoftwig/twigcs/issues",
-                "source": "https://github.com/friendsoftwig/twigcs/tree/6.2.0"
-            },
-            "time": "2023-01-13T16:02:00+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
```
Changelogs summary:

 - friendsoftwig/twigcs removed (installed version was 6.2.0)

No security vulnerability advisories found.
```