### PR TITLE
Upgrade phpstan to 1.10.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 
 - PHP_CodeSniffer [3.7.2](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2)
 - PHP-CS-Fixer [3.40.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.40.0)
-- PHPStan [1.10.44](https://github.com/phpstan/phpstan/releases/tag/1.10.44)
+- PHPStan [1.10.46](https://github.com/phpstan/phpstan/releases/tag/1.10.46)
 - PHP Insights [2.10.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.10.0)
 - YML Linter
 - Twig Linter 

--- a/composer.lock
+++ b/composer.lock
@@ -5667,16 +5667,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.44",
+            "version": "1.10.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b"
+                "reference": "90d3d25c5b98b8068916bbf08ce42d5cb6c54e70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf84367c53a23f759513985c54ffe0d0c249825b",
-                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/90d3d25c5b98b8068916bbf08ce42d5cb6c54e70",
+                "reference": "90d3d25c5b98b8068916bbf08ce42d5cb6c54e70",
                 "shasum": ""
             },
             "require": {
@@ -5725,7 +5725,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-21T16:30:46+00:00"
+            "time": "2023-11-28T14:57:26+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
```
Changelogs summary:

 - phpstan/phpstan updated from 1.10.44 to 1.10.46 patch
   See changes: https://github.com/phpstan/phpstan/compare/1.10.44...1.10.46
   Release notes: https://github.com/phpstan/phpstan/releases/tag/1.10.46

No security vulnerability advisories found.

```