### PR TITLE
Upgrade phpstan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 
 - PHP_CodeSniffer [3.8.0](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.8.0)
 - PHP-CS-Fixer [3.41.1](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.41.1)
-- PHPStan [1.10.49](https://github.com/phpstan/phpstan/releases/tag/1.10.49)
+- PHPStan [1.10.50](https://github.com/phpstan/phpstan/releases/tag/1.10.50)
 - PHP Insights [2.11.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.11.0)
 - YML Linter
 - Twig Linter 

--- a/composer.lock
+++ b/composer.lock
@@ -5182,16 +5182,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.4",
+            "version": "1.24.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496"
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6bd0c26f3786cd9b7c359675cb789e35a8e07496",
-                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
                 "shasum": ""
             },
             "require": {
@@ -5223,22 +5223,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
             },
-            "time": "2023-11-26T18:29:22+00:00"
+            "time": "2023-12-16T09:33:33+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.49",
+            "version": "1.10.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "9367ba4c4f6ad53e9efb594d74a8941563caccf6"
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9367ba4c4f6ad53e9efb594d74a8941563caccf6",
-                "reference": "9367ba4c4f6ad53e9efb594d74a8941563caccf6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
                 "shasum": ""
             },
             "require": {
@@ -5287,7 +5287,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-12T10:05:12+00:00"
+            "time": "2023-12-13T10:59:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
```
Changelogs summary:

 - phpstan/phpdoc-parser updated from 1.24.4 to 1.24.5 patch
   See changes: https://github.com/phpstan/phpdoc-parser/compare/1.24.4...1.24.5
   Release notes: https://github.com/phpstan/phpdoc-parser/releases/tag/1.24.5

 - phpstan/phpstan updated from 1.10.49 to 1.10.50 patch
   See changes: https://github.com/phpstan/phpstan/compare/1.10.49...1.10.50
   Release notes: https://github.com/phpstan/phpstan/releases/tag/1.10.50

No security vulnerability advisories found.

```