### PR TITLE
Adding phpstan-todo-by

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "phpunit/phpunit": "^9.6",
         "pyrech/composer-changelogs": "^2.1",
         "squizlabs/php_codesniffer": "^3.7",
+        "staabm/phpstan-todo-by": "^0.1.3",
         "symfony/browser-kit": "^7.0",
         "symfony/css-selector": "^7.0",
         "symfony/maker-bundle": "^1.46",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2f20c24d65d346d56d96c9a22a87cab",
+    "content-hash": "41bf8e24124ffae978bd799942d47e05",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -6927,6 +6927,62 @@
                 }
             ],
             "time": "2023-12-08T12:32:31+00:00"
+        },
+        {
+            "name": "staabm/phpstan-todo-by",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/phpstan-todo-by.git",
+                "reference": "c1755856ffb2bad43f2b5bd269b66c2709a56fc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/phpstan-todo-by/zipball/c1755856ffb2bad43f2b5bd269b66c2709a56fc6",
+                "reference": "c1755856ffb2bad43f2b5bd269b66c2709a56fc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9 || ^10.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "staabm\\PHPStanTodoBy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "PHPStan",
+                "dev",
+                "phpstan-extension",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/phpstan-todo-by/issues",
+                "source": "https://github.com/staabm/phpstan-todo-by/tree/0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-16T10:13:03+00:00"
         },
         {
             "name": "symfony/browser-kit",


### PR DESCRIPTION
```
Changelogs summary:

 - staabm/phpstan-todo-by installed in version 0.1.3
   Release notes: https://github.com/staabm/phpstan-todo-by/releases/tag/0.1.3

No security vulnerability advisories found.

```

fix #55 