### PR TITLE
update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Or use `make restart-without-xdebug` if `sed` is installed on your machine.
 
 ### QA tools: 
 
-- PHP_CodeSniffer [3.8.0](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.8.0)
-- PHP-CS-Fixer [3.45.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.45.0)
-- PHPStan [1.10.50](https://github.com/phpstan/phpstan/releases/tag/1.10.50)
+- PHP_CodeSniffer [3.8.1](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.8.1)
+- PHP-CS-Fixer [3.46.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.46.0)
+- PHPStan [1.10.55](https://github.com/phpstan/phpstan/releases/tag/1.10.55)
 - PHP Insights [2.11.0](https://github.com/nunomaduro/phpinsights/releases/tag/v2.11.0)
 - YML Linter
 - Twig Linter 

--- a/composer.lock
+++ b/composer.lock
@@ -2558,16 +2558,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v2.4.2",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36"
+                "reference": "6b44ac75c7f07f48159ec36c2d21ef8cf48a21b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
-                "reference": "67ee785f1aedada76461de7a7ec10cd7f8ff8d36",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/6b44ac75c7f07f48159ec36c2d21ef8cf48a21b1",
+                "reference": "6b44ac75c7f07f48159ec36c2d21ef8cf48a21b1",
                 "shasum": ""
             },
             "require": {
@@ -2603,7 +2603,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v2.4.2"
+                "source": "https://github.com/symfony/flex/tree/v2.4.3"
             },
             "funding": [
                 {
@@ -2619,7 +2619,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-05T14:09:35+00:00"
+            "time": "2024-01-02T11:08:32+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -4506,21 +4506,22 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.45.0",
+            "version": "v3.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "c0daa33cb2533cd73f48dde1c70c2afa3e7953b5"
+                "reference": "be6831c9af1740470d2a773119b9273f8ac1c3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/c0daa33cb2533cd73f48dde1c70c2afa3e7953b5",
-                "reference": "c0daa33cb2533cd73f48dde1c70c2afa3e7953b5",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/be6831c9af1740470d2a773119b9273f8ac1c3d2",
+                "reference": "be6831c9af1740470d2a773119b9273f8ac1c3d2",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
@@ -4584,7 +4585,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.45.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.46.0"
             },
             "funding": [
                 {
@@ -4592,7 +4593,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-30T02:07:07+00:00"
+            "time": "2024-01-03T21:38:46+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -5309,16 +5310,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.5",
+            "version": "1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
                 "shasum": ""
             },
             "require": {
@@ -5350,22 +5351,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
             },
-            "time": "2023-12-16T09:33:33+00:00"
+            "time": "2024-01-04T17:06:16+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.50",
+            "version": "1.10.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+                "reference": "9a88f9d18ddf4cf54c922fbeac16c4cb164c5949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9a88f9d18ddf4cf54c922fbeac16c4cb164c5949",
+                "reference": "9a88f9d18ddf4cf54c922fbeac16c4cb164c5949",
                 "shasum": ""
             },
             "require": {
@@ -5414,7 +5415,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T10:59:42+00:00"
+            "time": "2024-01-08T12:32:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6977,16 +6978,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -6996,11 +6997,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -7053,20 +7054,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "staabm/phpstan-todo-by",
-            "version": "0.1.16",
+            "version": "0.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/staabm/phpstan-todo-by.git",
-                "reference": "98d37d9dcfbcf1a70bb7a36ecea7c6ca7430c347"
+                "reference": "0a3ce2ca5bf0cc5dba0a62fc8790a34d92de4486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/staabm/phpstan-todo-by/zipball/98d37d9dcfbcf1a70bb7a36ecea7c6ca7430c347",
-                "reference": "98d37d9dcfbcf1a70bb7a36ecea7c6ca7430c347",
+                "url": "https://api.github.com/repos/staabm/phpstan-todo-by/zipball/0a3ce2ca5bf0cc5dba0a62fc8790a34d92de4486",
+                "reference": "0a3ce2ca5bf0cc5dba0a62fc8790a34d92de4486",
                 "shasum": ""
             },
             "require": {
@@ -7075,11 +7076,11 @@
                 "ext-curl": "*",
                 "ext-json": "*",
                 "nikolaposa/version": "^4.1",
-                "php": "^7.4 || ^8.0"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^1.10"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.41",
-                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9 || ^10.5",
                 "redaxo/php-cs-fixer-config": "^1.0"
             },
@@ -7110,7 +7111,7 @@
             ],
             "support": {
                 "issues": "https://github.com/staabm/phpstan-todo-by/issues",
-                "source": "https://github.com/staabm/phpstan-todo-by/tree/0.1.16"
+                "source": "https://github.com/staabm/phpstan-todo-by/tree/0.1.21"
             },
             "funding": [
                 {
@@ -7118,7 +7119,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-27T15:47:46+00:00"
+            "time": "2024-01-08T20:36:55+00:00"
         },
         {
             "name": "symfony/browser-kit",


### PR DESCRIPTION
```
Changelogs summary:

 - symfony/flex updated from v2.4.2 to v2.4.3 patch
   See changes: https://github.com/symfony/flex/compare/v2.4.2...v2.4.3
   Release notes: https://github.com/symfony/flex/releases/tag/v2.4.3

 - squizlabs/php_codesniffer updated from 3.8.0 to 3.8.1 patch
   See changes: https://github.com/PHPCSStandards/PHP_CodeSniffer/compare/3.8.0...3.8.1
   Release notes: https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.1

 - phpstan/phpdoc-parser updated from 1.24.5 to 1.25.0 minor
   See changes: https://github.com/phpstan/phpdoc-parser/compare/1.24.5...1.25.0
   Release notes: https://github.com/phpstan/phpdoc-parser/releases/tag/1.25.0

 - friendsofphp/php-cs-fixer updated from v3.45.0 to v3.46.0 minor
   See changes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.45.0...v3.46.0
   Release notes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.46.0

 - phpstan/phpstan updated from 1.10.50 to 1.10.55 patch
   See changes: https://github.com/phpstan/phpstan/compare/1.10.50...1.10.55
   Release notes: https://github.com/phpstan/phpstan/releases/tag/1.10.55

 - staabm/phpstan-todo-by updated from 0.1.16 to 0.1.21 patch
   See changes: https://github.com/staabm/phpstan-todo-by/compare/0.1.16...0.1.21
   Release notes: https://github.com/staabm/phpstan-todo-by/releases/tag/0.1.21

No security vulnerability advisories found.

```